### PR TITLE
Bugfix/jrd/spy error on r58 upgrade apml 443

### DIFF
--- a/seeq/addons/correlation/utils/_sdl.py
+++ b/seeq/addons/correlation/utils/_sdl.py
@@ -32,8 +32,7 @@ def pull_only_signals(url, grid='auto'):
         return pd.DataFrame()
     search_signals_df = search_df[search_df['Type'].str.contains('Signal')]
 
-    df = spy.pull(search_signals_df, start=start, end=end, grid=grid, header='ID', quiet=True,
-                  status=status)
+    df = spy.pull(search_signals_df, start=start, end=end, grid=grid, header='ID', status=status)
     if df.empty:
         return pd.DataFrame()
 

--- a/seeq/addons/correlation/utils/_sdl.py
+++ b/seeq/addons/correlation/utils/_sdl.py
@@ -25,6 +25,7 @@ def pull_only_signals(url, grid='auto'):
     worksheet = spy.utils.get_analysis_worksheet_from_url(url)
     start = worksheet.display_range['Start']
     end = worksheet.display_range['End']
+    status=spy.Status(quiet=True)
 
     search_df = spy.search(url, estimate_sample_period=worksheet.display_range, quiet=True)
     if search_df.empty:
@@ -32,7 +33,7 @@ def pull_only_signals(url, grid='auto'):
     search_signals_df = search_df[search_df['Type'].str.contains('Signal')]
 
     df = spy.pull(search_signals_df, start=start, end=end, grid=grid, header='ID', quiet=True,
-                  status=spy.Status(quiet=True))
+                  status=status)
     if df.empty:
         return pd.DataFrame()
 


### PR DESCRIPTION
This PR fixes a bug that occurs due to spy when upgrading to R58.  The change uses a spy.status(quiet=True) object as the status within a spy.pull, rather than setting quiet=True inside of spy.pull.