### PR TITLE
Use status instead of quiet=True APML-819

### DIFF
--- a/seeq/addons/correlation/utils/_sdl.py
+++ b/seeq/addons/correlation/utils/_sdl.py
@@ -26,9 +26,9 @@ def pull_only_signals(url, grid='auto'):
     worksheet = spy.utils.get_analysis_worksheet_from_url(url)
     start = worksheet.display_range['Start']
     end = worksheet.display_range['End']
-    status=spy.Status(quiet=True)
+    status = spy.Status(quiet=True)
 
-    search_df = spy.search(url, estimate_sample_period=worksheet.display_range, quiet=True)
+    search_df = spy.search(url, estimate_sample_period=worksheet.display_range, status=status)
     if search_df.empty:
         return pd.DataFrame()
     search_signals_df = search_df[search_df['Type'].str.contains('Signal')]


### PR DESCRIPTION
This PR fixes the spy Error caused by usiing both `spy.Status(quiet=True)`  and `quiet=True` flag together.

https://seeq.atlassian.net/browse/APML-819