### PR TITLE
CRAB-48351: Switch Correlation to use to `import_package()` to create UDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Correlation is included in the default list of available Add-ons. Simply search 
 and click "Install".
 
 ## Manual Installation
-If you want to install **seeq-correlation** manually or Add-on Manager is not availible, you can do so by 
+If you want to install **seeq-correlation** manually or Add-on Manager is not available, you can do so by 
 following the steps below.
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -41,15 +41,23 @@ section [Use Cases](https://seeq12.github.io/seeq-correlation/examples.html).
 
 # Installation
 
-The backend of **seeq-correlation** requires **Python 3.7** or later.
+The easiest way to install **seeq-correlation** is to use Add-on Manager from Seeq Workbench. 
+Correlation is included in the default list of available Add-ons. Simply search for "Correlation" in the manager
+and click "Install".
 
-## Dependencies
+## Manual Installation
+If you want to install **seeq-correlation** manually or Add-on Manager is not availible, you can do so by 
+following the steps below.
+
+### Dependencies
+
+The backend of **seeq-correlation** requires **Python 3.7** or later.
 
 See [`requirements.txt`](https://github.com/seeq12/seeq-correlation/tree/master/requirements.txt) file for a list of
 dependencies and versions. Additionally, you will need to install the `seeq` module with the appropriate version that
 matches your Seeq server. For more information on the `seeq` module see [seeq at pypi](https://pypi.org/project/seeq/)
 
-## User Installation Requirements (Seeq Data Lab)
+### User Installation Requirements (Seeq Data Lab)
 
 If you want to install **seeq-correlation** as a Seeq Add-on Tool, you will need:
 
@@ -58,7 +66,7 @@ If you want to install **seeq-correlation** as a Seeq Add-on Tool, you will need
 - Seeq administrator access
 - Enable Add-on Tools in the Seeq server
 
-## User Installation (Seeq Data Lab)
+### User Installation (Seeq Data Lab)
 
 The latest build of the project can be found [here](https://pypi.org/project/seeq-correlation/) as a wheel file. The
 file is published as a courtesy to the user, and it does not imply any obligation for support from the publisher.

--- a/docs_src/source/conf.py
+++ b/docs_src/source/conf.py
@@ -21,7 +21,7 @@ from seeq.addons import correlation
 
 project = 'seeq-correlation'
 copyright = '2021, Seeq Corporation'
-author = 'Alberto Rivas'
+author = 'Seeq Corporation'
 
 # The full version, including alpha/beta/rc tags
 version = correlation.__version__

--- a/seeq/addons/correlation/utils/_sdl.py
+++ b/seeq/addons/correlation/utils/_sdl.py
@@ -98,10 +98,8 @@ def get_seeq_url():
     return None
 
 def check_udf_package(name="CrossCorrelationAddOn", api_client=None):
-    if api_client:
-        formulas_api = sdk.FormulasApi(api_client)
-    else:
-        formulas_api = sdk.FormulasApi(spy.client)
+    client = api_client if api_client else spy.client
+    formulas_api = sdk.FormulasApi(client)
     try:
         formulas_api.get_package(package_name=name)
         return True


### PR DESCRIPTION
Instead of calling `formulas_api.put_package()` and all the other API calls to create the user-defined functions, Correlation now uses `formulas_api.import_package()`. This is the same function as Add-on Manager uses. Given the new Data IDs that we pass in for the UDFs, this should make Correlation installed via the WHL file fully compatible with the version installed from AoM.

(Remove the `.zip` from the end of these files. I had to add them for Github.)
[correlation.addon.zip](https://github.com/user-attachments/files/19694749/correlation.addon.zip)
[seeq_correlation-0.3.0-py38-none-any.whl.zip](https://github.com/user-attachments/files/19694755/seeq_correlation-0.3.0-py38-none-any.whl.zip)
