### PR TITLE
APML-857: Teamcity build failure fix caused by jupyter 1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ dask>=2021.10.0
 ipython
 ipyvuetify==1.6.2
 ipywidgets==7.6.3
-jupyter==1.1.1
+jupyter==1.1.0
 matplotlib==3.3.4
 memoization==0.3.2
 myst-parser~=0.15.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ dask>=2021.10.0
 ipython
 ipyvuetify==1.6.2
 ipywidgets==7.6.3
-jupyter==1.1.0
+jupyter>=1.1.0
 matplotlib==3.3.4
 memoization==0.3.2
 myst-parser~=0.15.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ parver==0.3.1
 plotly==4.14.3
 pytest==6.2.4
 pytest-xdist==2.2.1
-python-dateutil==2.8.1
+python-dateutil>=2.8.1
 scikit-learn>=1.0.1
 scipy==1.6.1
 seaborn==0.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ dask>=2021.10.0
 ipython
 ipyvuetify==1.6.2
 ipywidgets==7.6.3
-jupyter~=1.0.0
+jupyter==1.1.1
 matplotlib==3.3.4
 memoization==0.3.2
 myst-parser~=0.15.2


### PR DESCRIPTION
This PR fixes the build failure https://teamcity.seeq-labs.com/buildConfiguration/AppliedResearch_correlation/894103 by specifying to use `jupyter>=1.1.1`.

Teamcity test passed at https://teamcity.seeq-labs.com/buildConfiguration/AppliedResearch_correlation/895297